### PR TITLE
fix: corrigindo erro de não geração de código pelo lombok

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -8,7 +8,7 @@
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
-          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/unknown/lombok-unknown.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.36/lombok-1.18.36.jar" />
         </processorPath>
         <module name="application" />
       </profile>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -29,6 +29,7 @@
 	<properties>
 		<java.version>21</java.version>
 		<spring-ai.version>1.0.0-M4</spring-ai.version>
+		<lombok.version>1.18.36</lombok.version>
 	</properties>
 
 	<dependencies>
@@ -76,6 +77,8 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
+			<scope>provided</scope>
 			<optional>true</optional>
 		</dependency>
 
@@ -108,6 +111,12 @@
 			<artifactId>postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.github.cdimascio</groupId>
+			<artifactId>dotenv-java</artifactId>
+			<version>3.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>
@@ -132,6 +141,7 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -1,1 +1,11 @@
-spring.application.name=application
+spring:
+  application:
+    name: application
+  datasource:
+    url: jdbc:postgresql://localhost:5432/devquest
+    username: postgres
+    password: password
+    driver-class-name: org.postgresql.Driver
+  ai:
+    openai:
+      api-key: ${SPRING_AI_OPENAI_API_KEY}


### PR DESCRIPTION
Mudei o arquivo pom.xml adicionando a versão específica do lombok no path do build para corrigir o erro.
Aproveitei e adicionei a dependencia dotenv-java para referenciar uma variável do arquivo .env diretamente no application.yml