### PR TITLE
Feature/increase generate exercise logic

### DIFF
--- a/app/src/main/java/devquest/application/controllers/ExerciseRestController.java
+++ b/app/src/main/java/devquest/application/controllers/ExerciseRestController.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/exercicios")
@@ -48,10 +45,12 @@ public class ExerciseRestController {
   )
   @GetMapping("/gerar")
   public ResponseEntity<ExerciseResponseDTO> generateExercise(
+          @RequestHeader("Authorization") String token,
           @RequestParam(name = "tecnologia") Technology technology,
           @RequestParam(name = "dificuldade") Difficulty difficulty
           ) {
-    return service.generateExercise(technology, difficulty);
+
+    return service.generateExercise(token, technology, difficulty);
   }
 
 }

--- a/app/src/main/java/devquest/application/repositories/ExerciseRepository.java
+++ b/app/src/main/java/devquest/application/repositories/ExerciseRepository.java
@@ -1,9 +1,26 @@
 package devquest.application.repositories;
 
+import devquest.application.enums.Difficulty;
+import devquest.application.enums.Technology;
 import devquest.application.model.entities.Exercise;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
 
 @Repository
 public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
+
+  @Query("SELECT e FROM Exercise e WHERE e.technology = :technology AND e.difficulty = :difficulty")
+  List<Exercise> findAllByTechnologyAndDifficulty(@PathVariable("technology") Technology technology,
+                                                  @PathVariable("difficulty") Difficulty difficulty);
+
+
+  @Query(value = "SELECT COUNT(*) = 0 FROM user_exercise WHERE user_id = :userId AND exercise_id = :exerciseId",
+          nativeQuery = true)
+  boolean userNotAnswerExercise(@PathVariable("exerciseId") Long exerciseId,
+                                @PathVariable("userId") Long userId);
+
 }

--- a/app/src/main/java/devquest/application/services/ExerciseService.java
+++ b/app/src/main/java/devquest/application/services/ExerciseService.java
@@ -7,6 +7,6 @@ import org.springframework.http.ResponseEntity;
 
 public interface ExerciseService {
 
-  ResponseEntity<ExerciseResponseDTO> generateExercise(Technology technology, Difficulty difficulty);
+  ResponseEntity<ExerciseResponseDTO> generateExercise(String token, Technology technology, Difficulty difficulty);
 
 }

--- a/app/src/main/java/devquest/application/services/impl/ExerciseServiceImpl.java
+++ b/app/src/main/java/devquest/application/services/impl/ExerciseServiceImpl.java
@@ -5,6 +5,8 @@ import devquest.application.enums.Technology;
 import devquest.application.model.dtos.response.exercises.ExerciseResponseDTO;
 import devquest.application.services.ExerciseService;
 import devquest.application.services.subservices.exercise.GenerateExerciseService;
+import devquest.application.services.subservices.exercise.SearchUnansweredExerciseService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -12,13 +14,26 @@ import org.springframework.stereotype.Service;
 public class ExerciseServiceImpl implements ExerciseService {
 
   private GenerateExerciseService generateExerciseService;
+  private SearchUnansweredExerciseService searchUnansweredExerciseService;
 
-  public ExerciseServiceImpl(GenerateExerciseService generateExerciseService) {
+  public ExerciseServiceImpl(GenerateExerciseService generateExerciseService,
+                             SearchUnansweredExerciseService searchUnansweredExerciseService) {
+
     this.generateExerciseService = generateExerciseService;
+    this.searchUnansweredExerciseService = searchUnansweredExerciseService;
   }
 
   @Override
-  public ResponseEntity<ExerciseResponseDTO> generateExercise(Technology technology, Difficulty difficulty) {
+  public ResponseEntity<ExerciseResponseDTO> generateExercise(String token,
+                                                              Technology technology,
+                                                              Difficulty difficulty) {
+
+    ExerciseResponseDTO unansweredExercise = searchUnansweredExerciseService
+            .getUnansweredExercise(token, technology, difficulty);
+
+    if (unansweredExercise != null)
+      return new ResponseEntity<>(unansweredExercise, HttpStatus.OK);
+
     return generateExerciseService.generateExercise(technology, difficulty);
   }
 

--- a/app/src/main/java/devquest/application/services/subservices/exercise/GenerateExerciseService.java
+++ b/app/src/main/java/devquest/application/services/subservices/exercise/GenerateExerciseService.java
@@ -17,7 +17,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Set;
 
 @Service
@@ -47,8 +46,7 @@ public class GenerateExerciseService {
     String formatedPrompt = promptFormatter.formatExercisePrompt(technology, difficulty);
     String exerciseString = openaiCaller.callOpenai(formatedPrompt);
     Exercise exercise = createAndSaveExercise(exerciseString, technology, difficulty);
-    Set<ExerciseInstruction> exerciseInstructions = createAndSaveInstructions(exerciseString, exercise);
-    exercise.setInstructions(exerciseInstructions);
+    createAndSaveInstructions(exerciseString, exercise);
     ExerciseResponseDTO exerciseResponseDTO = convertExerciseInExerciseResponseDTO(exercise);
 
     return new ResponseEntity<>(exerciseResponseDTO, HttpStatus.OK);
@@ -65,17 +63,14 @@ public class GenerateExerciseService {
     return repository.save(exercise);
   }
 
-  private Set<ExerciseInstruction> createAndSaveInstructions(String exerciseString, Exercise exercise) {
+  private void createAndSaveInstructions(String exerciseString, Exercise exercise) {
     Set<String> instructionsString = stringParser.getEnumerationBetweenFlags(exerciseString,
             "INSTRUÇÕES:", null);
-    Set<ExerciseInstruction> instructions = new HashSet<>();
     instructionsString.forEach(i -> {
       String[] parts = stringParser.getArrayWithEnumeratorIndicatorAndText(i, "\\.");
       ExerciseInstruction exerciseInstruction = createAndSaveExerciseInstruction(parts, exercise);
-      instructions.add(exerciseInstruction);
+      exercise.addInstruction(exerciseInstruction);
     });
-
-    return instructions;
   }
 
   private ExerciseInstruction createAndSaveExerciseInstruction(String[] parts, Exercise exercise) {

--- a/app/src/main/java/devquest/application/services/subservices/exercise/SearchUnansweredExerciseService.java
+++ b/app/src/main/java/devquest/application/services/subservices/exercise/SearchUnansweredExerciseService.java
@@ -1,0 +1,66 @@
+package devquest.application.services.subservices.exercise;
+
+import devquest.application.dozermapper.DozerMapper;
+import devquest.application.enums.Difficulty;
+import devquest.application.enums.Technology;
+import devquest.application.model.dtos.response.exercises.ExerciseResponseDTO;
+import devquest.application.model.entities.Exercise;
+import devquest.application.model.entities.User;
+import devquest.application.repositories.ExerciseRepository;
+import devquest.application.repositories.UserRepository;
+import devquest.application.utilities.TokenJwtDecoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class SearchUnansweredExerciseService {
+
+  private ExerciseRepository exerciseRepository;
+  private UserRepository userRepository;
+  private TokenJwtDecoder tokenJwtDecoder;
+
+  public SearchUnansweredExerciseService(ExerciseRepository exerciseRepository,
+                                         UserRepository userRepository,
+                                         TokenJwtDecoder tokenJwtDecoder) {
+
+    this.exerciseRepository = exerciseRepository;
+    this.userRepository = userRepository;
+    this.tokenJwtDecoder = tokenJwtDecoder;
+  }
+
+  public ExerciseResponseDTO getUnansweredExercise(String token, Technology technology, Difficulty difficulty) {
+    List<Exercise> exercises = getAllExercisesWithThisTechnologyAndDifficulty(technology, difficulty);
+    if (checkIfExerciseListIsNull(exercises)) return null;
+    User user = decodeTokenAndGetUser(token);
+    Exercise unansweredExercise = findForExerciseUnansweredByUser(exercises, user);
+    if (unansweredExercise == null) return null;
+
+    return convertToDTO(unansweredExercise);
+  }
+
+  private List<Exercise> getAllExercisesWithThisTechnologyAndDifficulty(Technology technology, Difficulty difficulty) {
+    return exerciseRepository.findAllByTechnologyAndDifficulty(technology, difficulty);
+  }
+
+  private boolean checkIfExerciseListIsNull(List<Exercise> exercises) {
+    return exercises.isEmpty();
+  }
+
+  private User decodeTokenAndGetUser(String token) {
+    String username = tokenJwtDecoder.getTokenSubject(token);
+    return userRepository.findByUsername(username);
+  }
+
+  private Exercise findForExerciseUnansweredByUser(List<Exercise> exercises, User user) {
+    return exercises.stream()
+            .filter(exercise -> exerciseRepository.userNotAnswerExercise(exercise.getId(), user.getId()))
+            .findFirst()
+            .orElse(null);
+  }
+
+  private ExerciseResponseDTO convertToDTO(Exercise exercise) {
+    return DozerMapper.parseObject(exercise, ExerciseResponseDTO.class);
+  }
+
+}


### PR DESCRIPTION
Nessa branch fiz uma adição à lógica de gerar exercício. Agora, com os usuários realizando requisições já autenticados na API e passando seu token JWT, a API vai implementar a lógica de buscar algum exercício que já está salvo no banco de dados, mas que não foi respondido pelo usuário. Se houver, a API retorna esse exercício para ele. Do contrário, ela gera um novo e retorna. Isso economiza recursos e chamadas à API do chatGPT.